### PR TITLE
Упрощение отображения лейблов и изменение логики кнопки Рассчитать

### DIFF
--- a/components/AfterForInput.tsx
+++ b/components/AfterForInput.tsx
@@ -1,13 +1,13 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 const AfterForInput = styled.div`
-    position: relative;
-    right: 10px;
-    top: -35px;
-    text-align: right;
-    font-size: 18px;
-    pointer-events: none;
-    height: 0px;
+  position: relative;
+  right: 10px;
+  top: -35px;
+  text-align: right;
+  font-size: 18px;
+  pointer-events: none;
+  height: 0px;
 `;
 
 export default AfterForInput;

--- a/components/AfterForInput.tsx
+++ b/components/AfterForInput.tsx
@@ -1,74 +1,13 @@
 import styled from 'styled-components';
 
-const AfterForInput = styled.label`
-  &::after {
-    position: absolute;
-    left: 637px;
-    bottom: 14px;
+const AfterForInput = styled.div`
+    position: relative;
+    right: 10px;
+    top: -35px;
+    text-align: right;
     font-size: 18px;
-    content: ${(props) => props.placeholder};
-  }
-
-  @media (max-width: 1630px) {
-    &::after {
-      left: 625px;
-  }
-
-  @media (max-width: 1450px) {
-    &::after {
-      left: 545px;
-  }
-  
-  @media (max-width: 1210px) {
-    &::after {
-      left: 935px;
-  }
-
-  @media (max-width: 1030px) {
-    &::after {
-      left: 790px;
-  }
-
-  @media (max-width: 930px) {
-    &::after {
-      left: 685px;
-  }
-
-  @media (max-width: 810px) {
-    &::after {
-      left: 585px;
-  }
-
-  @media (max-width: 775px) {
-    &::after {
-      left: 565px;
-  }
-
-  @media (max-width: 675px) {
-    &::after {
-      left: 470px;
-  }
-
-  @media (max-width: 600px) {
-    &::after {
-      left: 415px;
-  }
-
-  @media (max-width: 430px) {
-    &::after {
-      left: 310px;
-  }
-
-  @media (max-width: 380px) {
-    &::after {
-      left: 260px;
-  }
-
-  @media (max-width: 330px) {
-    &::after {
-      left: 220px;
-  }
- 
+    pointer-events: none;
+    height: 0px;
 `;
 
 export default AfterForInput;

--- a/components/AfterForOutput.tsx
+++ b/components/AfterForOutput.tsx
@@ -1,80 +1,13 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
-const AfterForOutput = styled.label`
-  &::after {
-    position: absolute;
-    font-size: 22px;
-    line-height: 26px;
-    color: #373e81;
-    right: -670px;
-    bottom: 40px;
-    content: ${(props) => props.placeholder};
-  }
-
-  @media (max-width: 1630px) {
-    &::after {
-      right: -660px;
-  }
-
-  @media (max-width: 1450px) {
-    &::after {
-      right: -580px;
-  }
-
-  @media (max-width: 1330px) {
-    &::after {
-      right: -500px;
-  }
-
-  @media (max-width: 1210px) {
-    &::after {
-      right: 20px;
-  }
-
-  @media (max-width: 1030px) {
-    &::after {
-      left: 785px;
-  }
-
-  @media (max-width: 930px) {
-    &::after {
-      left: 675px;
-  }
-
-  @media (max-width: 810px) {
-    &::after {
-      left: 585px;
-  }
-
-  @media (max-width: 775px) {
-    &::after {
-      left: 555px;
-  }
-
-  @media (max-width: 675px) {
-    &::after {
-      left: 460px;
-  }
-
-  @media (max-width: 600px) {
-    &::after {
-      left: 410px;
-  }
-
-  @media (max-width: 430px) {
-    &::after {
-      left: 310px;
-  }
-
-  @media (max-width: 380px) {
-    &::after {
-      left: 260px;
-  }
-
-  @media (max-width: 330px) {
-    &::after {
-      left: 220px;
-  }
+const AfterForOutput = styled.div`
+  position: relative;
+  right: 16px;
+  top: -80px;
+  text-align: right;
+  font-size: 22px;
+  pointer-events: none;
+  height: 10px;
 `;
 
 export default AfterForOutput;

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -17,9 +17,6 @@ const Input = styled.input`
     outline: none;
     border-color: #777;
   }
-  & + label {
-    position: relative;
-  }
   &:invalid:not(:placeholder-shown) {
     border-color: red;
   }

--- a/components/Input.tsx
+++ b/components/Input.tsx
@@ -15,7 +15,7 @@ const Input = styled.input`
   }
   &:focus {
     outline: none;
-    border-color: #777;
+    border-color: #006aff;
   }
   &:invalid:not(:placeholder-shown) {
     border-color: red;

--- a/components/Output.tsx
+++ b/components/Output.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 const Output = styled.input`
   color: #373e81;
@@ -12,10 +12,6 @@ const Output = styled.input`
 
   &::placeholder {
     color: #373e81;
-  }
-
-  & + label {
-    position: relative;
   }
 
   @media (max-width: 1220px) {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -136,8 +136,8 @@ const Home: NextPage = () => {
           disabled
           value={`${output.length > 0 ? output[0].toLocaleString() : output}`}
         />
-        <AfterForOutput placeholder="'руб'" />
       </Wrapper>
+      <AfterForOutput>руб</AfterForOutput>
       <Wrapper>
         <Label>Для такого кредита рекомендованный доход:</Label>
         <Output
@@ -145,8 +145,8 @@ const Home: NextPage = () => {
           disabled
           value={`${output.length > 0 ? output[1].toLocaleString() : output}`}
         />
-        <AfterForOutput placeholder="'руб'" />
       </Wrapper>
+      <AfterForOutput>руб</AfterForOutput>
       <Wrapper>
         <Label>Налоговый вычет, который можно получить:</Label>
         <Output
@@ -154,8 +154,8 @@ const Home: NextPage = () => {
           disabled
           value={`${output.length > 0 ? output[2].toLocaleString() : output}`}
         />
-        <AfterForOutput placeholder="'руб'" />
       </Wrapper>
+      <AfterForOutput>руб</AfterForOutput>
       <Wrapper>
         <Label>Переплата за срок кредитования:</Label>
         <Output
@@ -163,8 +163,8 @@ const Home: NextPage = () => {
           disabled
           value={`${output.length > 0 ? output[3].toLocaleString() : output}`}
         />
-        <AfterForOutput placeholder="'руб'" />
       </Wrapper>
+      <AfterForOutput>руб</AfterForOutput>
     </>
   );
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,32 +1,32 @@
-import type { NextPage } from 'next';
-import styled from 'styled-components';
-import Title from '../components/Title';
-import Form from '../components/Form';
-import Section from '../components/Section';
-import Button from '../components/Button';
-import Input from '../components/Input';
-import AfterForInput from '../components/AfterForInput';
-import Wrapper from '../components/Wrapper';
-import Label from '../components/Label';
-import Output from '../components/Output';
-import AfterForOutput from '../components/AfterForOutput';
-import { useState, useEffect, useRef } from 'react';
+import type { NextPage } from "next";
+import styled from "styled-components";
+import Title from "../components/Title";
+import Form from "../components/Form";
+import Section from "../components/Section";
+import Button from "../components/Button";
+import Input from "../components/Input";
+import AfterForInput from "../components/AfterForInput";
+import Wrapper from "../components/Wrapper";
+import Label from "../components/Label";
+import Output from "../components/Output";
+import AfterForOutput from "../components/AfterForOutput";
+import { useState, useEffect, useRef } from "react";
 
 const Description = styled(Section)`
   grid-row: 1/-5;
 `;
 
 const Home: NextPage = () => {
-  const [loanCost, setLoanCost] = useState('');
-  const [percent, setPercent] = useState('');
-  const [month, setMonth] = useState('');
+  const [loanCost, setLoanCost] = useState("");
+  const [percent, setPercent] = useState("");
+  const [month, setMonth] = useState("");
   const [output, setOutput] = useState<number[]>([]);
 
   const loanCostInput = useRef() as React.MutableRefObject<HTMLInputElement>;
   useEffect(() => loanCostInput.current.focus(), []);
 
   const runk = function (value: string): string {
-    return value.replace(/\D/g, '').replace(/(\d)(?=(\d{3})+$)/g, '$1 ');
+    return value.replace(/\D/g, "").replace(/(\d)(?=(\d{3})+$)/g, "$1 ");
   };
 
   const onSubmit = (e: any) => {
@@ -37,11 +37,11 @@ const Home: NextPage = () => {
     const monthNum: number = +month;
 
     if (loanCostNum < 10000 || loanCostNum > 10000000)
-      return alert('Введите корректную стоимость кредита, пожалуйста!');
+      return alert("Введите корректную стоимость кредита, пожалуйста!");
     if (percentNum < 1 || percentNum > 1000)
-      return alert('Введите корректную процентную ставку, пожалуйста!');
+      return alert("Введите корректную процентную ставку, пожалуйста!");
     if (monthNum < 1 || monthNum > 1000)
-      return alert('Введите корректный срок кредитования, пожалуйста!');
+      return alert("Введите корректный срок кредитования, пожалуйста!");
 
     const percentMonth = percentNum / 12 / 100;
     const factorAnnuat =
@@ -55,9 +55,9 @@ const Home: NextPage = () => {
 
     setOutput([payment, income, taxDeduction, overPayment]);
 
-    setLoanCost('');
-    setPercent('');
-    setMonth('');
+    setLoanCost("");
+    setPercent("");
+    setMonth("");
   };
   return (
     <>
@@ -85,11 +85,11 @@ const Home: NextPage = () => {
             autoFocus
             maxLength={10}
             required
-            color={loanCost.length > 4 || loanCost.length === 0 ? '' : 'red'}
+            color={loanCost.length > 4 || loanCost.length === 0 ? "" : "red"}
             value={runk(loanCost)}
-            onChange={(e) => setLoanCost(e.target.value.replace(/\D/g, ''))}
+            onChange={(e) => setLoanCost(e.target.value.replace(/\D/g, ""))}
           />
-          <AfterForInput placeholder="'руб'" />
+          <AfterForInput>руб</AfterForInput>
         </div>
         <div>
           <Input
@@ -98,9 +98,9 @@ const Home: NextPage = () => {
             maxLength={5}
             required
             value={runk(percent)}
-            onChange={(e) => setPercent(e.target.value.replace(/\D/g, ''))}
+            onChange={(e) => setPercent(e.target.value.replace(/\D/g, ""))}
           />
-          <AfterForInput placeholder="'%'" />
+          <AfterForInput>%</AfterForInput>
         </div>
         <div>
           <Input
@@ -109,9 +109,9 @@ const Home: NextPage = () => {
             maxLength={3}
             required
             value={runk(month)}
-            onChange={(e) => setMonth(e.target.value.replace(/\D/g, ''))}
+            onChange={(e) => setMonth(e.target.value.replace(/\D/g, ""))}
           />
-          <AfterForInput placeholder="'мес'" />
+          <AfterForInput>мес</AfterForInput>
         </div>
         <Button
           type="submit"
@@ -122,8 +122,8 @@ const Home: NextPage = () => {
           }
           className={`${
             loanCost.length > 0 || percent.length > 0 || month.length > 0
-              ? 'on'
-              : ''
+              ? "on"
+              : ""
           }`}
         >
           Рассчитать

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,6 +21,7 @@ const Home: NextPage = () => {
   const [percent, setPercent] = useState("");
   const [month, setMonth] = useState("");
   const [output, setOutput] = useState<number[]>([]);
+  const [activeButton, setActiveButton] = useState<boolean>(false);
 
   const loanCostInput = useRef() as React.MutableRefObject<HTMLInputElement>;
   useEffect(() => loanCostInput.current.focus(), []);
@@ -55,10 +56,17 @@ const Home: NextPage = () => {
 
     setOutput([payment, income, taxDeduction, overPayment]);
 
-    setLoanCost("");
-    setPercent("");
-    setMonth("");
+    setActiveButton(false);
   };
+
+  useEffect(() => {
+    if (loanCost.length > 0 && percent.length > 0 && month.length > 0) {
+      setActiveButton(true);
+    } else {
+      setActiveButton(false);
+    }
+  }, [loanCost, percent, month]);
+
   return (
     <>
       <Title>Кредитный калькулятор</Title>
@@ -115,16 +123,8 @@ const Home: NextPage = () => {
         </div>
         <Button
           type="submit"
-          disabled={
-            loanCost.length > 0 || percent.length > 0 || month.length > 0
-              ? false
-              : true
-          }
-          className={`${
-            loanCost.length > 0 || percent.length > 0 || month.length > 0
-              ? "on"
-              : ""
-          }`}
+          disabled={!activeButton}
+          className={`${activeButton ? "on" : ""}`}
         >
           Рассчитать
         </Button>


### PR DESCRIPTION
1. Изменения лейблов - теперь они при ЛЮБОМ размере экрана привязаны к правому боку input объекта, плюс очень сильно упрощён код css. (теперь не съезжают при нестандартном размере экрана, а их много)
2. Небольшие корректировки кода, в особенности - добавление новой переменной статуса кнопки и вынесение логики отображения кнопки в отдельную функцию, которая возвращает boolean значение для кнопки, так как код уже повторялся, а как плюс - для следующего пункта эта логика нужна.
3. Изменена логика на Рассчитать - теперь поля не очищаются, потому что изначально не планировалось, что они будут очищаться, плюс это неудобно, ты уже не видишь введенные данные и можешь забыть какой процент вводил, какую сумму и тем более месяц.  Плюс логика в ТЗ была что если после нажатия кнопки Рассчитать - то кнопка становится неактивной до первого изменения любого поля, чтобы было видно, что данные уже изменены и нужно перерассчитать.